### PR TITLE
arrow option is missing from 'PopperOptions'

### DIFF
--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -108,12 +108,15 @@ declare namespace Popper {
     eventsEnabled?: boolean;
     modifiers?: Modifiers;
     removeOnDestroy?: boolean;
-
+    arrow?: {
+      element: HTMLElement,
+      enable: boolean
+    },
     onCreate?(data: Data): void;
 
     onUpdate?(data: Data): void;
   }
-
+  
   export interface ReferenceObject {
     clientHeight: number;
     clientWidth: number;


### PR DESCRIPTION
just added Arrow option to PopperOptions declaration.

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
